### PR TITLE
fix errors found when debug is set to true in WordPress and upgraded

### DIFF
--- a/theme-functions/theme-options.php
+++ b/theme-functions/theme-options.php
@@ -6,6 +6,7 @@ function twentytwelve_child_theme_menu()
 add_action('admin_menu', 'twentytwelve_child_theme_menu');
 function theme_options_settings()
 {
+	$return = "";
 	$temlate_sidebar = array(
 						"publication-template" 	=> "page-templates/publication-template.php",
 						"toolkit-template" 		=> "page-templates/toolkit-template.php",
@@ -15,7 +16,7 @@ function theme_options_settings()
 
 	if(isset($_REQUEST) && !empty($_REQUEST))
 	{
-		if($_REQUEST["action"] == "widget_assign")
+		if(isset($_REQUEST["action"]) && $_REQUEST["action"] == "widget_assign")
 		{
 			global $wp_registered_sidebars, $wp_registered_widgets;
 			$page_id = $_REQUEST["page_id"];

--- a/tinymce_button/shortcode_button.php
+++ b/tinymce_button/shortcode_button.php
@@ -1,6 +1,7 @@
 <?php
 add_action('admin_head', 'oet_add_tinyme_button');
-add_action('media_buttons_context', 'oet_media_buttons_context');
+//add_action('media_buttons_context', 'oet_media_buttons_context');
+add_action('media_buttons', 'oet_media_buttons_context');
 add_action('admin_print_footer_scripts', 'oet_add_quicktags');
 function oet_add_quicktags()
 {
@@ -12,7 +13,7 @@ function oet_add_quicktags()
 	</script>
 <?php
 }
-function oet_media_buttons_context()
+function oet_media_buttons_context($context)
 {
 	 global $post_ID, $temp_ID;
 	$iframe_ID = (int) (0 == $post_ID ? $temp_ID : $post_ID);


### PR DESCRIPTION
…hook call from "media_buttons_context" to "media_buttons" as the former is deprecated.